### PR TITLE
Make Image Loading Asynchronous

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -98,9 +98,9 @@ fn muff() -> Result<(), String> {
         let mut pb = ProgressBar::new(image_size);
         pb.message("Reading image: ");
         pb.set_units(Units::Bytes);
-
-        let data = image
-            .read(|total| {
+        let mut data = Vec::new();
+        image
+            .read(&mut data, |total| {
                 pb.set(total);
             })
             .map_err(|err| format!("image error with image at '{}': {}", image_path, err))?;

--- a/gtk/src/ui/content/images.rs
+++ b/gtk/src/ui/content/images.rs
@@ -2,11 +2,12 @@ use gtk::*;
 use pango::EllipsizeMode;
 
 pub struct ImageView {
-    pub container:  Box,
-    pub chooser:    Button,
-    pub image_path: Label,
-    pub hash:       ComboBoxText,
-    pub hash_label: Entry,
+    pub container:         Box,
+    pub chooser_container: Stack,
+    pub chooser:           Button,
+    pub image_path:        Label,
+    pub hash:              ComboBoxText,
+    pub hash_label:        Entry,
 }
 
 impl ImageView {
@@ -34,6 +35,21 @@ impl ImageView {
         image_path.set_ellipsize(EllipsizeMode::End);
         image_path.get_style_context().map(|c| c.add_class("bold"));
 
+        let button_box = Box::new(Orientation::Vertical, 0);
+        button_box.pack_start(&chooser, false, false, 0);
+        button_box.pack_start(&image_path, false, false, 0);
+
+        let spinner = Spinner::new();
+        spinner.start();
+        let spinner_label = Label::new("Loading Image");
+        spinner_label
+            .get_style_context()
+            .map(|c| c.add_class("bold"));
+
+        let spinner_box = Box::new(Orientation::Vertical, 0);
+        spinner_box.pack_start(&spinner, false, false, 0);
+        spinner_box.pack_start(&spinner_label, false, false, 0);
+
         let hash = ComboBoxText::new();
         hash.append_text("Type");
         hash.append_text("SHA256");
@@ -50,9 +66,10 @@ impl ImageView {
         hash_container.pack_start(&hash, false, false, 0);
         hash_container.pack_start(&hash_label, true, true, 0);
 
-        let chooser_container = Box::new(Orientation::Vertical, 5);
-        chooser_container.pack_start(&chooser, false, false, 0);
-        chooser_container.pack_start(&image_path, false, false, 0);
+        let chooser_container = Stack::new();
+        chooser_container.add_named(&button_box, "chooser");
+        chooser_container.add_named(&spinner_box, "loader");
+        chooser_container.set_visible_child_name("chooser");
 
         let left_panel = Box::new(Orientation::Vertical, 0);
         left_panel
@@ -75,6 +92,7 @@ impl ImageView {
 
         ImageView {
             container,
+            chooser_container,
             chooser,
             image_path,
             hash,

--- a/gtk/src/ui/ui.css
+++ b/gtk/src/ui/ui.css
@@ -1,6 +1,4 @@
 .left-panel {
-    background-color: @theme_fg_color;
-    box-shadow: 0 0 .3em;
     margin-right: .5em;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,19 @@ impl Image {
     pub fn get_size(&self) -> u64 { self.size }
 
     /// Reads the image into a vector, and reports progress to a callback.
-    pub fn read<P: FnMut(u64)>(&mut self, mut progress_callback: P) -> Result<Vec<u8>, ImageError> {
-        let mut data = vec![0; self.size as usize];
+    pub fn read<P: FnMut(u64)>(
+        &mut self,
+        data: &mut Vec<u8>,
+        mut progress_callback: P,
+    ) -> Result<(), ImageError> {
+        if data.capacity() < self.size as usize {
+            let capacity = self.size as usize - data.capacity();
+            data.reserve_exact(capacity);
+            data.append(&mut vec![0; capacity])
+        } else if data.capacity() > self.size as usize {
+            data.truncate(self.size as usize);
+            data.shrink_to_fit();
+        }
 
         let mut total = 0;
         while total < data.len() {
@@ -88,7 +99,7 @@ impl Image {
             progress_callback(total as u64);
         }
 
-        Ok(data)
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Image buffering now happens in a separate long-running thread in the background, which receives image paths to load from a `Receiver`, and sets the corresponding values within an atomic integer so that the state changes within the UI will know what's happening in the thread.

When an image is being loaded, the button will be hidden, and replaced with a spinner.

And the background color & box shadow within the left panel has been unset.

The library will also re-use a pre-existing `Vec<u8>`, truncating or extending it as required, rather than recreating a new one.

Closes #8 
Closes #11